### PR TITLE
Stylus integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 
 # only generated for size check
 my-element.bundled.js
+
+.DS_STORE
+
+style.css

--- a/dev/index.html
+++ b/dev/index.html
@@ -5,6 +5,8 @@
     <meta charset="utf-8">
     <title>&lt;my-element> Demo</title>
     <script type="module" src="../my-element.js"></script>
+    <link href="../index.css" rel="stylesheet">
+
     <style>
       p {
         border: solid 1px blue;

--- a/dev/index.html
+++ b/dev/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <title>&lt;my-element> Demo</title>
     <script type="module" src="../my-element.js"></script>
+    <!-- This import applies all styles outside of web components -->
     <link href="../dev/static/css/style.css" rel="stylesheet">
 
     <style>

--- a/dev/index.html
+++ b/dev/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <title>&lt;my-element> Demo</title>
     <script type="module" src="../my-element.js"></script>
-    <link href="../index.css" rel="stylesheet">
+    <link href="../dev/static/css/style.css" rel="stylesheet">
 
     <style>
       p {

--- a/dev/static/stylus/my-element.styl
+++ b/dev/static/stylus/my-element.styl
@@ -1,0 +1,3 @@
+.my-element-button {
+    background-color: blue; 
+}

--- a/dev/static/stylus/style.styl
+++ b/dev/static/stylus/style.styl
@@ -1,3 +1,10 @@
+/*
+Set up stylus compiling with LitElement
+https://stackoverflow.com/questions/48828233/react-component-library-getting-stylus-to-work
+
+*/
+@import 'my-element'
+
 body
   font: 12px/1.4 "Lucida Grande", Arial, sans-serif
   background: black

--- a/dev/static/stylus/style.styl
+++ b/dev/static/stylus/style.styl
@@ -1,0 +1,4 @@
+body
+  font: 12px/1.4 "Lucida Grande", Arial, sans-serif
+  background: black
+  color: #ccc

--- a/index.css
+++ b/index.css
@@ -1,0 +1,3 @@
+body {
+  background-color: pink;
+}

--- a/index.css
+++ b/index.css
@@ -1,3 +1,0 @@
-body {
-  background-color: pink;
-}

--- a/my-element.js
+++ b/my-element.js
@@ -56,6 +56,7 @@ export class MyElement extends LitElement {
 
   render() {
     return html`
+      <!-- This import applies .my-element-button styles inside of #shadow-root -->
       <link href="/dev/static/css/style.css" rel="stylesheet" />
 
       <h1>Hello, ${this.name}!</h1>

--- a/my-element.js
+++ b/my-element.js
@@ -14,6 +14,8 @@
 
 import {LitElement, html, css} from 'lit-element';
 
+// importing styles with webpack & litelement: https://github.com/drdreo/lit-scss-loader
+
 /**
  * An example element.
  *
@@ -54,8 +56,10 @@ export class MyElement extends LitElement {
 
   render() {
     return html`
+      <link href="/dev/static/css/style.css" rel="stylesheet" />
+
       <h1>Hello, ${this.name}!</h1>
-      <button @click=${this._onClick} part="button">
+      <button class="my-element-button" @click=${this._onClick} part="button">
         Click Count: ${this.count}
       </button>
       <slot></slot>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8768,6 +8768,12 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -9366,6 +9372,79 @@
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "dev": true
     },
+    "npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -9809,6 +9888,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
       "integrity": "sha1-7N++p3BK21/m+0f5hmxMDhXpBcU=",
+      "dev": true
+    },
+    "pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
       "dev": true
     },
     "pify": {
@@ -11065,6 +11150,12 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shell-quote": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "dev": true
+    },
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
@@ -11547,6 +11638,16 @@
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
+      }
+    },
+    "string.prototype.padend": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz",
+      "integrity": "sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "string.prototype.trimend": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "test:watch": "karma start karma.conf.cjs --auto-watch=true --single-run=false",
     "test:update-snapshots": "karma start karma.conf.cjs --update-snapshots",
     "test:prune-snapshots": "karma start karma.conf.cjs --prune-snapshots",
-    "checksize": "rollup -c ; cat my-element.bundled.js | gzip -9 | wc -c ; rm my-element.bundled.js"
+    "checksize": "rollup -c ; cat my-element.bundled.js | gzip -9 | wc -c ; rm my-element.bundled.js",
+    "build-css": "stylus -c dev/static/stylus/ --out dev/static/css",
+    "watch-css": "npm run build-css && stylus -c -w dev/static/stylus/ --out dev/static/css",
+    "start": "npm-run-all -p watch-css serve"
   },
   "keywords": [
     "web-components",
@@ -51,6 +54,7 @@
     "karma-mocha": "^1.3.0",
     "lit-analyzer": "^1.1.9",
     "mocha": "^7.1.1",
+    "npm-run-all": "^4.1.5",
     "prettier": "^2.0.4",
     "rimraf": "^3.0.2",
     "rollup": "^1.32.1",


### PR DESCRIPTION
Static Build:
- stylus with package.json (this approach is pretty similar to how we currently bundle stylus)
- link compiled css into index.html for css outside of shadow root (this approach is pretty similar to how we currently bundle stylus)
- link compiled css into my-element.js for css inside of shadow root component. this is not optimized because it's pulling in _all_ css instead of just what we need. the loader link below allows for importing styles and then using those in the styles() section of the component. 


https://github.com/drdreo/lit-scss-loader
^ this looks promising if using webpack ... 